### PR TITLE
(vitineth/healthchecks) adds healthchecks to the system that integrate with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14
 
+HEALTHCHECK CMD node node_modules/.bin/healthcheck
+
 # Setup where to store the app
 WORKDIR /user/app
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
-    "@uems/micro-builder": "0.0.13",
+    "@uems/micro-builder": "1.0.1",
     "@uems/uemscommlib": "0.1.0-beta.38",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",

--- a/src/DatabaseConnector.ts
+++ b/src/DatabaseConnector.ts
@@ -1,9 +1,9 @@
 import * as zod from 'zod';
 import * as MongoClient from 'mongodb';
 import { EventDatabase } from './database/type/impl/EventDatabaseInterface';
-import { GenericCommentDatabase } from '@uems/micro-builder/build/database/GenericCommentDatabase';
 import { SignupDatabase } from './database/type/impl/SignupDatabaseInterface';
 import { _byFile } from './logging/Log';
+import { GenericCommentDatabase } from '@uems/micro-builder/build/src';
 
 const _l = _byFile(__filename);
 

--- a/src/DatabaseConnector.ts
+++ b/src/DatabaseConnector.ts
@@ -3,7 +3,7 @@ import * as MongoClient from 'mongodb';
 import { EventDatabase } from './database/type/impl/EventDatabaseInterface';
 import { SignupDatabase } from './database/type/impl/SignupDatabaseInterface';
 import { _byFile } from './logging/Log';
-import { GenericCommentDatabase } from '@uems/micro-builder/build/src';
+import { GenericCommentDatabase, tryApplyTrait } from '@uems/micro-builder/build/src';
 
 const _l = _byFile(__filename);
 
@@ -36,6 +36,7 @@ export namespace Database {
     export async function connect(config: any): Promise<DatabaseConnections> {
         const validate = CONFIG_VALIDATOR.safeParse(config);
         if (!validate.success) {
+            tryApplyTrait('database', false);
             throw new Error(`Failed to validate config: ${JSON.stringify(validate.error.flatten())}`);
         }
         _l.info('database configuration was valid');
@@ -68,6 +69,7 @@ export namespace Database {
             };
         } catch (e) {
             _l.error('failed to connect to the database', e);
+            tryApplyTrait('database', false);
             throw e;
         }
     }

--- a/src/MessageConnector.ts
+++ b/src/MessageConnector.ts
@@ -1,6 +1,7 @@
 import { Channel, connect as amqpConnect, Connection, Message, } from 'amqplib';
 
 import { CommentMessageValidator, SignupMessageValidator, CommentResponse, EventMessageValidator, EventResponse, MessageValidator, SignupResponse } from '@uems/uemscommlib';
+import { tryApplyTrait } from "@uems/micro-builder/build/src";
 
 const fs = require('fs').promises;
 
@@ -118,10 +119,12 @@ export namespace Messaging {
             conn.on('error', (err: Error) => {
                 if (err.message !== 'Connection closing') {
                     console.error('[AMQP] conn error', err.message);
+                    tryApplyTrait('rabbitmq', false);
                 }
             });
             conn.on('close', () => {
                 console.error('[AMQP] connection closed');
+                tryApplyTrait('rabbitmq', false);
             });
             console.log('[AMQP] connected');
 
@@ -192,6 +195,7 @@ export namespace Messaging {
                     return res;
                 } catch (e) {
                     console.error('Failed to connect to rabbit mq', e);
+                    tryApplyTrait('rabbitmq', false);
 
                     // This forces a timeout before retrying connection.
                     // eslint-disable-next-line no-await-in-loop

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,8 @@ import { Messaging } from './MessageConnector';
 import morgan from 'morgan';
 import { EventDatabase } from './database/type/impl/EventDatabaseInterface';
 import { CommentResponse, MsgStatus, SignupResponse, BaseSchema, EventResponse } from '@uems/uemscommlib';
-import { GenericCommentDatabase } from '@uems/micro-builder/build/database/GenericCommentDatabase';
 import { SignupDatabase } from './database/type/impl/SignupDatabaseInterface';
 import { _byFile } from './logging/Log';
-import { ClientFacingError } from '@uems/micro-builder/build/errors/ClientFacingError';
 import express = require('express');
 import cookieParser = require('cookie-parser');
 import DatabaseConnections = Database.DatabaseConnections;
@@ -15,8 +13,7 @@ import ShallowInternalComment = CommentResponse.ShallowInternalComment;
 import ShallowInternalSignup = SignupResponse.ShallowInternalSignup;
 import Intentions = BaseSchema.Intentions;
 import ShallowInternalEvent = EventResponse.ShallowInternalEvent;
-import SignupServiceReadResponseMessage = SignupResponse.SignupServiceReadResponseMessage;
-import SignupReadResponseMessage = SignupResponse.SignupReadResponseMessage;
+import { ClientFacingError, GenericCommentDatabase } from '@uems/micro-builder/build/src';
 
 const fs = require('fs').promises;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import { Database } from './DatabaseConnector';
 import { Messaging } from './MessageConnector';
 import morgan from 'morgan';
 import { EventDatabase } from './database/type/impl/EventDatabaseInterface';
-import { CommentResponse, MsgStatus, SignupResponse, BaseSchema, EventResponse } from '@uems/uemscommlib';
+import { CommentResponse, MsgStatus, SignupResponse, BaseSchema, EventResponse, has } from '@uems/uemscommlib';
 import { SignupDatabase } from './database/type/impl/SignupDatabaseInterface';
 import { _byFile } from './logging/Log';
 import express = require('express');
@@ -13,7 +13,29 @@ import ShallowInternalComment = CommentResponse.ShallowInternalComment;
 import ShallowInternalSignup = SignupResponse.ShallowInternalSignup;
 import Intentions = BaseSchema.Intentions;
 import ShallowInternalEvent = EventResponse.ShallowInternalEvent;
-import { ClientFacingError, GenericCommentDatabase } from '@uems/micro-builder/build/src';
+import { ClientFacingError, GenericCommentDatabase, launchCheck, tryApplyTrait } from '@uems/micro-builder/build/src';
+
+// @ts-ignore
+const requestTracker: ('success' | 'fail')[] & { save: (d: 'success' | 'fail') => void } = [];
+requestTracker.save = function save(d) {
+    if (requestTracker.length >= 50) requestTracker.shift();
+    requestTracker.push(d);
+    tryApplyTrait('successful', requestTracker.filter((e) => e === 'success').length);
+    tryApplyTrait('fail', requestTracker.filter((e) => e === 'fail').length);
+};
+
+launchCheck(['successful', 'errored', 'rabbitmq', 'database'], (traits: Record<string, any>) => {
+    if (has(traits, 'rabbitmq') && traits.rabbitmq !== '_undefined' && !traits.rabbitmq) return 'unhealthy';
+    if (has(traits, 'database') && traits.database !== '_undefined' && !traits.database) return 'unhealthy';
+
+    // If 75% of results fail then we return false
+    if (has(traits, 'successful') && has(traits, 'errored')) {
+        const errorPercentage = traits.errored / (traits.successful + traits.errored);
+        if (errorPercentage > 0.05) return 'unhealthy-serving';
+    }
+
+    return 'healthy';
+});
 
 const fs = require('fs').promises;
 
@@ -40,18 +62,23 @@ const handleSignup = (
     _l.debug(`received signup message for ${content.msg_intention}`);
     switch (content.msg_intention) {
         case 'CREATE':
+            requestTracker.save('success');
             resolve(signup.create(content));
             break;
         case 'DELETE':
+            requestTracker.save('success');
             resolve(signup.delete(content));
             break;
         case 'READ':
+            requestTracker.save('success');
             resolve(signup.query(content));
             break;
         case 'UPDATE':
+            requestTracker.save('success');
             resolve(signup.update(content));
             break;
         default:
+            requestTracker.save('fail');
             reject(new ClientFacingError(`invalid message intention: + ${content.msg_intention}`));
     }
 });
@@ -63,18 +90,23 @@ const handleComment = (
     _l.debug(`received comment message for ${content.msg_intention}`);
     switch (content.msg_intention) {
         case 'CREATE':
+            requestTracker.save('success');
             resolve(comment.create(content));
             break;
         case 'DELETE':
+            requestTracker.save('success');
             resolve(comment.delete(content));
             break;
         case 'READ':
+            requestTracker.save('success');
             resolve(comment.query(content));
             break;
         case 'UPDATE':
+            requestTracker.save('success');
             resolve(comment.update(content));
             break;
         default:
+            requestTracker.save('fail');
             reject(new ClientFacingError(`invalid message intention: + ${content.msg_intention}`));
     }
 });
@@ -83,14 +115,19 @@ const handleEvent = async (content: any, event: EventDatabase): Promise<string[]
     _l.debug(`received comment message for ${content.msg_intention}`);
     switch (content.msg_intention) {
         case 'CREATE':
+            requestTracker.save('success');
             return event.create(content);
         case 'DELETE':
+            requestTracker.save('success');
             return event.delete(content);
         case 'READ':
+            requestTracker.save('success');
             return event.query(content);
         case 'UPDATE':
+            requestTracker.save('success');
             return event.update(content);
         default:
+            requestTracker.save('fail');
             throw new ClientFacingError(`invalid message intention: + ${content.msg_intention}`);
     }
 };
@@ -219,7 +256,7 @@ async function reqReceived(
  * @param eventsConnection the resolved database object
  */
 async function databaseConnectionReady(eventsConnection: DatabaseConnections) {
-
+    tryApplyTrait('database', true);
     _l.info('database connections are setup correctly', { keys: Object.keys(eventsConnection) });
 
     eventDatabase = eventsConnection.event;
@@ -231,6 +268,8 @@ async function databaseConnectionReady(eventsConnection: DatabaseConnections) {
         reqReceived,
         [EVENT_DETAILS_SERVICE_TOPIC, EVENT_COMMENTS_SERVICE_TOPIC, EVENT_SIGNUPS_SERVICE_TOPIC],
     );
+
+    tryApplyTrait('rabbitmq', true);
 
     app.listen(process.env.PORT, () => {
         _l.info('Event micro dionysus started successfully');
@@ -251,6 +290,7 @@ async function setup() {
         .catch((e) => {
             _l.error('Event details microservice failed to connect to database... exiting');
             _l.error(e.message);
+            tryApplyTrait('database', false);
             process.exit(1);
         });
 }

--- a/src/database/type/impl/EventDatabaseInterface.ts
+++ b/src/database/type/impl/EventDatabaseInterface.ts
@@ -2,14 +2,12 @@ import {
     Collection, Db, FilterQuery, ObjectID, UpdateQuery,
 } from 'mongodb';
 import { EventMessage, EventResponse } from '@uems/uemscommlib';
-import { GenericMongoDatabase, MongoDBConfiguration } from '@uems/micro-builder';
-import { genericCreate, genericDelete } from '@uems/micro-builder/build/utility/GenericDatabaseFunctions';
-import { ClientFacingError } from '@uems/micro-builder/build/errors/ClientFacingError';
 import ShallowInternalEvent = EventResponse.ShallowInternalEvent;
 import ReadEventMessage = EventMessage.ReadEventMessage;
 import CreateEventMessage = EventMessage.CreateEventMessage;
 import DeleteEventMessage = EventMessage.DeleteEventMessage;
 import UpdateEventMessage = EventMessage.UpdateEventMessage;
+import { ClientFacingError, genericCreate, genericDelete, GenericMongoDatabase, MongoDBConfiguration } from "@uems/micro-builder/build/src";
 
 // TODO: move to uems comms library
 export type Changelog = {

--- a/src/database/type/impl/SignupDatabaseInterface.ts
+++ b/src/database/type/impl/SignupDatabaseInterface.ts
@@ -1,13 +1,16 @@
-import { Collection, Db, FilterQuery, ObjectID } from 'mongodb';
+import {
+    Collection, Db, FilterQuery, ObjectID,
+} from 'mongodb';
 import { SignupMessage, SignupResponse } from '@uems/uemscommlib';
-import { GenericMongoDatabase, MongoDBConfiguration } from '@uems/micro-builder';
-import { genericCreate, genericDelete, genericUpdate } from '@uems/micro-builder/build/utility/GenericDatabaseFunctions';
 import { _byFile } from '../../../logging/Log';
 import CreateSignupMessage = SignupMessage.CreateSignupMessage;
 import ReadSignupMessage = SignupMessage.ReadSignupMessage;
 import DeleteSignupMessage = SignupMessage.DeleteSignupMessage;
 import UpdateSignupMessage = SignupMessage.UpdateSignupMessage;
 import ShallowInternalSignup = SignupResponse.ShallowInternalSignup;
+import {
+    genericCreate, genericDelete, GenericMongoDatabase, genericUpdate, MongoDBConfiguration,
+} from '@uems/micro-builder/build/src';
 
 const _l = _byFile(__filename);
 
@@ -39,14 +42,17 @@ const createToDB = (create: CreateSignupMessage): CreateInDatabaseSignup => ({
 export class SignupDatabase extends GenericMongoDatabase<ReadSignupMessage, CreateSignupMessage, DeleteSignupMessage, UpdateSignupMessage, ShallowInternalSignup> {
 
     constructor(_configuration: MongoDBConfiguration);
-    constructor(_configurationOrDB: MongoDBConfiguration | Db, collections?: MongoDBConfiguration["collections"]);
-    constructor(database: Db, collections: MongoDBConfiguration["collections"]);
-    constructor(configurationOrDB: MongoDBConfiguration | Db, collections?: MongoDBConfiguration["collections"]) {
+    constructor(_configurationOrDB: MongoDBConfiguration | Db, collections?: MongoDBConfiguration['collections']);
+    constructor(database: Db, collections: MongoDBConfiguration['collections']);
+    constructor(configurationOrDB: MongoDBConfiguration | Db, collections?: MongoDBConfiguration['collections']) {
         super(configurationOrDB, collections);
 
-
         const register = (details: Collection) => {
-            details.createIndex({ role: 1, user: 1, event: 1 }, { unique: true });
+            details.createIndex({
+                role: 1,
+                user: 1,
+                event: 1,
+            }, { unique: true });
         };
 
         if (this._details) {

--- a/tests/utilities/BindingBroker.ts
+++ b/tests/utilities/BindingBroker.ts
@@ -3,7 +3,7 @@ import CreateUserMessage = UserMessage.CreateUserMessage;
 import UpdateUserMessage = UserMessage.UpdateUserMessage;
 import DeleteUserMessage = UserMessage.DeleteUserMessage;
 import ReadUserMessage = UserMessage.ReadUserMessage;
-import { RabbitNetworkHandler } from "@uems/micro-builder";
+import { RabbitNetworkHandler } from "@uems/micro-builder/build/src";
 
 interface MockBrokerInterface<R, D, U, C, M> {
     on(name: 'query', callback: (message: R, send: (data: any) => void) => void, routingKey: string): void;


### PR DESCRIPTION
Rolling the same changes out across all repositories, this monitors the last 50 requests to health and also the database and rabbitmq connections. Should make docker healthchecks represent the actual state of the system. This will also override the current healthcheck in docker-compose in ents-crew/uems-hub.