### PR TITLE
Making service work without docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "clean": "rm -r build/ || true",
     "build": "tsc --listEmittedFiles",
     "start": "node -r source-map-support/register --trace-warnings ./build/src/app.js",
-    "start:dev": "NODE_ENV=dev ts-node --files ./src/app.js",
+    "start:dev": "NODE_ENV=dev ts-node --files ./src/app.ts",
     "test": "jest --runInBand"
   },
   "dependencies": {
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
-    "@uems/micro-builder": "1.0.1",
+    "@uems/micro-builder": "1.0.3",
     "@uems/uemscommlib": "0.1.0-beta.38",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc --listEmittedFiles",
     "start": "node -r source-map-support/register --trace-warnings ./build/src/app.js",
     "start:dev": "NODE_ENV=dev ts-node --files ./src/app.ts",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "dockerless": "UEMS_HEALTHCHECK=7778 NODE_ENV=dev npm run start:dev"
   },
   "dependencies": {
     "@types/amqplib": "^0.5.13",


### PR DESCRIPTION
This removes explicit dependency on docker by adding spport for relocating the config and updating the healthcheck port which allows it to run standalone