### PR TITLE
(vitineth/permission): adding permission support via keycloak

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
     "@uems/micro-builder": "1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.45",
+    "@uems/uemscommlib": "0.1.0-beta.48",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
     "@uems/micro-builder": "1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.48",
+    "@uems/uemscommlib": "0.1.0-beta.50",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/src/app.ts
+++ b/src/app.ts
@@ -138,7 +138,13 @@ function bind(broker: RabbitBrokerType) {
         if (routingKey.startsWith('events.signups')) {
             await handleSignupMessage(message as SignupMessage.SignupMessage, signupDatabase, send, routingKey);
         } else if (routingKey.startsWith('events.comment')) {
-            await handleCommentMessage(message as CommentMessage.CommentMessage, commentDatabase, send, routingKey);
+            await handleCommentMessage(
+                message as CommentMessage.CommentMessage,
+                commentDatabase,
+                eventDatabase,
+                send,
+                routingKey,
+            );
         } else {
             await handleEventMessage(message as EventMessage.EventMessage, eventDatabase, send, routingKey);
         }
@@ -190,9 +196,9 @@ async function databaseConnectionReady(eventsConnection: DatabaseConnections) {
     const jointIncoming = async (data: any) => {
         console.log('testing incoming', data, '===', await failToFalse(discoverIncoming.validate(data)));
         return (await failToFalse(eventIncoming.validate(data)))
-        || (await failToFalse(signupIncoming.validate(data)))
-        || (await failToFalse(discoverIncoming.validate(data)))
-        || (await failToFalse(commentIncoming.validate(data)));
+            || (await failToFalse(signupIncoming.validate(data)))
+            || (await failToFalse(discoverIncoming.validate(data)))
+            || (await failToFalse(commentIncoming.validate(data)));
     }
 
     const messenger: RabbitBrokerType = new RabbitNetworkHandler(

--- a/src/database/EventDatabaseInterface.ts
+++ b/src/database/EventDatabaseInterface.ts
@@ -219,6 +219,10 @@ export class EventDatabase extends GenericMongoDatabase<ReadEventMessage, Create
             };
         }
 
+        if (request.localOnly) {
+            query.author = request.userID;
+        }
+
         return query;
     }
 
@@ -281,7 +285,8 @@ export class EventDatabase extends GenericMongoDatabase<ReadEventMessage, Create
 
         let result;
         try {
-            result = await details.updateOne({ _id: new ObjectID(request.id) }, update);
+            const userIDFilter = request.localOnly ? { author: request.userID } : {};
+            result = await details.updateOne({ _id: new ObjectID(request.id), ...userIDFilter }, update);
         } catch (e) {
             if (e.code === 11000) {
                 throw new ClientFacingError('duplicate entity provided');

--- a/src/database/EventDatabaseInterface.ts
+++ b/src/database/EventDatabaseInterface.ts
@@ -26,6 +26,7 @@ export type InDatabaseEvent = {
     attendance: number,
     ents?: string,
     state?: string,
+    author: string,
 };
 
 export type CreateInDatabaseEvent = Omit<InDatabaseEvent, '_id'>;
@@ -39,6 +40,7 @@ const dbToIn = (db: InDatabaseEvent): ShallowInternalEvent => ({
     id: db._id.toHexString(),
     name: db.name,
     start: db.start,
+    author: db.author,
 });
 
 const createToDB = (create: CreateEventMessage): CreateInDatabaseEvent => ({
@@ -49,6 +51,7 @@ const createToDB = (create: CreateEventMessage): CreateInDatabaseEvent => ({
     end: create.end,
     ents: create.entsID === null ? undefined : create.entsID,
     state: create.stateID === null ? undefined : create.stateID,
+    author: create.userID,
 });
 
 export class EventDatabase extends GenericMongoDatabase<ReadEventMessage, CreateEventMessage, DeleteEventMessage, UpdateEventMessage, ShallowInternalEvent> {

--- a/src/database/SignupDatabaseInterface.ts
+++ b/src/database/SignupDatabaseInterface.ts
@@ -133,7 +133,13 @@ export class SignupDatabase extends GenericMongoDatabase<ReadSignupMessage, Crea
 
     protected deleteImpl(create: SignupMessage.DeleteSignupMessage, details: Collection): Promise<string[]> {
         if (!ObjectID.isValid(create.id)) throw new Error('invalid entity format');
-        return genericDelete({ _id: new ObjectID(create.id) }, create.id, details, this.log.bind(this));
+        const userIDFilter = create.localOnly ? { author: create.userID } : {};
+        return genericDelete(
+            { _id: new ObjectID(create.id), ...userIDFilter },
+            create.id,
+            details,
+            this.log.bind(this),
+        );
     }
 
     protected async queryImpl(
@@ -147,7 +153,8 @@ export class SignupDatabase extends GenericMongoDatabase<ReadSignupMessage, Crea
 
     protected updateImpl(create: SignupMessage.UpdateSignupMessage, details: Collection): Promise<string[]> {
         if (!ObjectID.isValid(create.id)) throw new Error('invalid entity format');
-        return genericUpdate(create, ['role'], details, {}, () => {
+        const userIDFilter = create.localOnly ? { author: create.userID } : {};
+        return genericUpdate(create, ['role'], details, userIDFilter, () => {
             throw new Error('signup already exists');
         });
     }

--- a/tests/db/event/create.test.ts
+++ b/tests/db/event/create.test.ts
@@ -70,7 +70,7 @@ describe('create messages of states', () => {
             .toHaveProperty('venues', ['a', 'b']);
         expect(query[0])
             .toHaveProperty('attendance', 1245);
-        expect(haveNoAdditionalKeys(query[0], ['id', 'name', 'state', 'ents', 'end', 'start', 'venues', 'attendance']));
+        expect(haveNoAdditionalKeys(query[0], ['id', 'name', 'state', 'ents', 'end', 'start', 'venues', 'attendance', 'author']));
     });
 
     it('should not add additional properties on create objects', async () => {
@@ -112,6 +112,6 @@ describe('create messages of states', () => {
             .toHaveProperty('venues', ['a', 'b']);
         expect(query[0])
             .toHaveProperty('attendance', 1245);
-        expect(haveNoAdditionalKeys(query[0], ['id', 'name', 'state', 'ents', 'end', 'start', 'venues', 'attendance']));
+        expect(haveNoAdditionalKeys(query[0], ['id', 'name', 'state', 'ents', 'end', 'start', 'venues', 'attendance', 'author']));
     });
 });

--- a/tests/db/event/query.test.ts
+++ b/tests/db/event/query.test.ts
@@ -147,4 +147,19 @@ describe('create messages of states', () => {
             .toContain('venus garlic');
     });
 
+    it('should limit results when querying with local only', async () => {
+        const query = await eventDB.query({
+            ...empty('READ'),
+            localOnly: true,
+            userID: 'asylum movement',
+        });
+
+        expect(query)
+            .toHaveLength(1);
+        expect(query[0])
+            .toHaveProperty('name', 'recommendation migration');
+        expect(query[0])
+            .toHaveProperty('state', 'teacher inside');
+    });
+
 });

--- a/tests/utilities/setup.ts
+++ b/tests/utilities/setup.ts
@@ -42,6 +42,7 @@ export const demoEventData: InDatabaseEvent[] = [
         start: 1612686824,
         venues: ['doll price', 'fraction fold'],
         attendance: 140,
+        author: 'throughful earthquake',
     },
     {
         _id: new ObjectId('6001f0d62712ee177867dcbc'),
@@ -52,6 +53,7 @@ export const demoEventData: InDatabaseEvent[] = [
         start: 1612686824,
         venues: ['dominant weave', 'doll price'],
         attendance: 185,
+        author: 'throughful earthquake',
     },
     {
         _id: new ObjectId('6001f0d62712ee177867dcbd'),
@@ -62,6 +64,7 @@ export const demoEventData: InDatabaseEvent[] = [
         start: 1611537944,
         venues: ['rubbish response', 'fraction fold'],
         attendance: 300,
+        author: 'throughful earthquake',
     },
 ];
 

--- a/tests/utilities/setup.ts
+++ b/tests/utilities/setup.ts
@@ -53,7 +53,7 @@ export const demoEventData: InDatabaseEvent[] = [
         start: 1612686824,
         venues: ['dominant weave', 'doll price'],
         attendance: 185,
-        author: 'throughful earthquake',
+        author: 'asylum movement',
     },
     {
         _id: new ObjectId('6001f0d62712ee177867dcbd'),


### PR DESCRIPTION
This integrates role based permissions as defined in keycloak. Four roles are defined
* admin
* extended
* ops
* ents

Admin should have permission to do everything on the system. Ops are allowed to manage venues, states, etc. Ents can view everything and are allowed to access the equipment regions. Extended is reserved for users between normal and ents where they can see all without editing anything. This will need to be updated later if required. 