### PR TITLE
(vitineth/permissions): signup delete permission upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
     "@uems/micro-builder": "1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.50",
+    "@uems/uemscommlib": "0.1.0-beta.51",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/src/binding/SignupBinding.ts
+++ b/src/binding/SignupBinding.ts
@@ -74,6 +74,19 @@ async function discover(
         modify: 0,
     };
 
+    if (message.assetType === 'signup') {
+        const userIDFilter = message.localAssetOnly ? { signupUser: message.userID } : {};
+
+        result.modify = (await database.query({
+            msg_id: message.msg_id,
+            userID: 'anonymous',
+            status: 0,
+            msg_intention: 'READ',
+            id: message.assetID,
+            ...userIDFilter,
+        })).length;
+    }
+
     if (message.assetType === 'event') {
         result.modify = (await database.query({
             msg_id: message.msg_id,
@@ -145,6 +158,29 @@ async function removeDiscover(
             status: 0,
             msg_intention: 'DELETE',
             id: entity.id,
+        })))).length;
+        result.successful = true;
+    }
+
+    if (message.assetType === 'signup') {
+        const userIDFilter = message.localAssetOnly ? { signupUser: message.userID } : {};
+
+        const entities = await database.query({
+            msg_id: message.msg_id,
+            userID: 'anonymous',
+            status: 0,
+            msg_intention: 'READ',
+            signupUser: message.assetID,
+            ...userIDFilter,
+        });
+
+        result.modified = (await Promise.all(entities.map((entity) => database.delete({
+            msg_id: message.msg_id,
+            userID: 'anonymous',
+            status: 0,
+            msg_intention: 'DELETE',
+            id: entity.id,
+            ...userIDFilter,
         })))).length;
         result.successful = true;
     }


### PR DESCRIPTION
The delete signup permission route did not have all the permissions required. This adds local only filtering to discovery and delete messages. This is only implemented on signups, however. 