### PR TITLE
(vitineth/feature/workflow): adding ops planning workflow with additional upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
-    "@uems/micro-builder": "1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.51",
+    "@uems/micro-builder": "1.0.4",
+    "@uems/uemscommlib": "0.1.0-beta.53",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
     "@uems/micro-builder": "1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.50",
+    "@uems/uemscommlib": "0.1.0-beta.51",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
     "@uems/micro-builder": "1.0.4",
-    "@uems/uemscommlib": "0.1.0-beta.54",
+    "@uems/uemscommlib": "0.1.0-beta.56",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
-    "@uems/micro-builder": "1.0.4",
+    "@uems/micro-builder": "1.1.0",
     "@uems/uemscommlib": "0.1.0-beta.56",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/amqplib": "^0.5.13",
     "@types/mocha": "^7.0.2",
     "@uems/micro-builder": "1.0.4",
-    "@uems/uemscommlib": "0.1.0-beta.53",
+    "@uems/uemscommlib": "0.1.0-beta.54",
     "ajv": "^6.12.3",
     "amqplib": "^0.5.6",
     "cookie-parser": "~1.4.4",

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,8 @@ import DiscoverMessage = DiscoveryMessage.DiscoverMessage;
 import { DiscoveryValidators } from "@uems/uemscommlib/build/discovery/DiscoveryValidators";
 import DiscoveryMessageValidator = DiscoveryValidators.DiscoveryMessageValidator;
 import DiscoveryResponseValidator = DiscoveryValidators.DiscoveryResponseValidator;
+import { configure as configureLog } from '@uems/micro-builder/build/src/logging/Log';
+import AMQPTransport from '@uems/micro-builder/build/src/logging/AMQPTransport';
 
 setupGlobalLogger();
 
@@ -194,12 +196,17 @@ async function databaseConnectionReady(eventsConnection: DatabaseConnections) {
         || (await failToFalse(discoverOutgoing.validate(data)))
         || (await failToFalse(commentOutgoing.validate(data)));
     const jointIncoming = async (data: any) => {
-        console.log('testing incoming', data, '===', await failToFalse(discoverIncoming.validate(data)));
+        // console.log('testing incoming', data, '===', await failToFalse(discoverIncoming.validate(data)));
         return (await failToFalse(eventIncoming.validate(data)))
             || (await failToFalse(signupIncoming.validate(data)))
             || (await failToFalse(discoverIncoming.validate(data)))
             || (await failToFalse(commentIncoming.validate(data)));
-    }
+    };
+
+    configureLog({
+        module: 'events',
+        transports: [await AMQPTransport(config.options)],
+    }, 'merge');
 
     const messenger: RabbitBrokerType = new RabbitNetworkHandler(
         config,

--- a/src/binding/CommentBinding.ts
+++ b/src/binding/CommentBinding.ts
@@ -37,6 +37,7 @@ async function create(
                     msg_intention: message.msg_intention,
                     status: MsgStatus.FAIL,
                     result: ['No valid asset found'],
+                    requestID: message.requestID,
                 };
             }
         } else {
@@ -46,6 +47,7 @@ async function create(
                 msg_intention: message.msg_intention,
                 status: MsgStatus.FAIL,
                 result: ['Cannot create local without assetID'],
+                requestID: message.requestID,
             };
         }
     }
@@ -57,6 +59,7 @@ async function create(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -71,6 +74,7 @@ async function update(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -85,6 +89,7 @@ async function remove(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -103,6 +108,7 @@ async function query(
                     msg_intention: message.msg_intention,
                     status: MsgStatus.FAIL,
                     result: ['No valid asset found'],
+                    requestID: message.requestID,
                 };
             }
         } else {
@@ -112,6 +118,7 @@ async function query(
                 msg_intention: message.msg_intention,
                 status: MsgStatus.FAIL,
                 result: ['Cannot query local without assetID'],
+                requestID: message.requestID,
             };
         }
     }
@@ -123,6 +130,7 @@ async function query(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -165,6 +173,7 @@ async function handleMessage(
             msg_intention: message.msg_intention,
             status: 405,
             result: [e.message],
+            requestID: message.requestID,
         });
     }
 

--- a/src/binding/EventBinding.ts
+++ b/src/binding/EventBinding.ts
@@ -15,6 +15,7 @@ async function create(
         userID: message.userID,
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
+        requestID: message.requestID,
         result,
     };
 }
@@ -29,6 +30,7 @@ async function update(
         userID: message.userID,
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
+        requestID: message.requestID,
         result,
     };
 }
@@ -43,6 +45,7 @@ async function remove(
         userID: message.userID,
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
+        requestID: message.requestID,
         result,
     };
 }
@@ -57,6 +60,7 @@ async function query(
         userID: message.userID,
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
+        requestID: message.requestID,
         result,
     };
 }
@@ -79,6 +83,7 @@ async function discover(
             msg_intention: message.msg_intention,
             modify: 0,
             restrict: 0,
+            requestID: message.requestID,
         };
     }
 
@@ -89,6 +94,7 @@ async function discover(
         msg_intention: 'READ',
         restrict: 0,
         modify: 0,
+        requestID: message.requestID,
     };
 
     if (message.assetType === 'venue') {
@@ -98,6 +104,7 @@ async function discover(
             status: 0,
             msg_intention: 'READ',
             anyVenues: [message.assetID],
+            requestID: message.requestID,
         })).length;
         _b.debug(`Discovery of venue returned restrict.${result.restrict} records`);
         return result;
@@ -110,6 +117,7 @@ async function discover(
             status: 0,
             msg_intention: 'READ',
             entsID: message.assetID,
+            requestID: message.requestID,
         })).length;
         _b.debug(`Discovery of ent state returned modify.${result.modify} records`);
         return result;
@@ -122,6 +130,7 @@ async function discover(
             status: 0,
             msg_intention: 'READ',
             stateID: message.assetID,
+            requestID: message.requestID,
         })).length;
         _b.debug(`Discovery of state returned modify.${result.modify} records`);
         return result;
@@ -134,6 +143,7 @@ async function discover(
             status: 0,
             msg_intention: 'READ',
             id: message.assetID,
+            requestID: message.requestID,
         })).length;
         _b.debug(`Discovery of event returned modify.${result.modify} records`);
         return result;
@@ -157,6 +167,7 @@ async function removeDiscover(
             modified: 0,
             restrict: 0,
             successful: true,
+            requestID: message.requestID,
         };
     }
 
@@ -168,6 +179,7 @@ async function removeDiscover(
         restrict: 0,
         modified: 0,
         successful: false,
+        requestID: message.requestID,
     };
 
     if (message.assetType === 'ent') {
@@ -294,12 +306,14 @@ async function handleMessage(
                 throw new Error('invalid message intention');
         }
     } catch (e) {
+        console.error(e);
         send({
             msg_id: message.msg_id,
             userID: message.userID,
             msg_intention: message.msg_intention,
             status: 405,
             result: [e.message],
+            requestID: message.requestID,
         });
     }
 

--- a/src/binding/SignupBinding.ts
+++ b/src/binding/SignupBinding.ts
@@ -74,6 +74,19 @@ async function discover(
         modify: 0,
     };
 
+    if (message.assetType === 'signup') {
+        const userIDFilter = message.localAssetOnly ? { signupUser: message.userID } : {};
+
+        result.modify = (await database.query({
+            msg_id: message.msg_id,
+            userID: 'anonymous',
+            status: 0,
+            msg_intention: 'READ',
+            id: message.assetID,
+            ...userIDFilter,
+        })).length;
+    }
+
     if (message.assetType === 'event') {
         result.modify = (await database.query({
             msg_id: message.msg_id,
@@ -145,6 +158,29 @@ async function removeDiscover(
             status: 0,
             msg_intention: 'DELETE',
             id: entity.id,
+        })))).length;
+        result.successful = true;
+    }
+
+    if (message.assetType === 'signup') {
+        const userIDFilter = message.localAssetOnly ? { signupUser: message.userID } : {};
+
+        const entities = await database.query({
+            msg_id: message.msg_id,
+            userID: 'anonymous',
+            status: 0,
+            msg_intention: 'READ',
+            signupUser: message.assetID,
+            ...userIDFilter,
+        });
+
+        result.modified = (await Promise.all(entities.map((entity) => database.delete({
+            msg_id: message.msg_id,
+            userID: 'anonymous',
+            status: 0,
+            msg_intention: 'DELETE',
+            id: entity.id,
+            ...userIDFilter,
         })))).length;
         result.successful = true;
     }

--- a/src/binding/SignupBinding.ts
+++ b/src/binding/SignupBinding.ts
@@ -16,6 +16,7 @@ async function create(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -30,6 +31,7 @@ async function update(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -44,6 +46,7 @@ async function remove(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -58,6 +61,7 @@ async function query(
         msg_intention: message.msg_intention,
         status: constants.HTTP_STATUS_OK,
         result,
+        requestID: message.requestID,
     };
 }
 
@@ -72,6 +76,7 @@ async function discover(
         msg_intention: 'READ',
         restrict: 0,
         modify: 0,
+        requestID: message.requestID,
     };
 
     if (message.assetType === 'signup') {
@@ -122,6 +127,7 @@ async function removeDiscover(
         restrict: 0,
         modified: 0,
         successful: false,
+        requestID: message.requestID,
     };
 
     if (message.assetType === 'event') {
@@ -235,6 +241,7 @@ async function handleMessage(
             msg_intention: message.msg_intention,
             status: 405,
             result: [e.message],
+            requestID: message.requestID,
         });
     }
 

--- a/src/database/EventDatabaseInterface.ts
+++ b/src/database/EventDatabaseInterface.ts
@@ -69,18 +69,18 @@ export class EventDatabase extends GenericMongoDatabase<ReadEventMessage, Create
     constructor(configurationOrDB: MongoDBConfiguration | Db, collections?: MongoDBConfiguration['collections']) {
         super(configurationOrDB, collections);
 
-        // const register = (details: Collection) => {
-        //     details.createIndex({ name: 'text' }, { unique: true });
-        // };
+        const register = (details: Collection) => {
+            details.createIndex({ name: 'text' });
+        };
 
-        // if (this._details) {
-        //     register(this._details);
-        // } else {
-        //     this.once('ready', () => {
-        //         if (!this._details) throw new Error('Details db was not initialised on ready');
-        //         register(this._details);
-        //     });
-        // }
+        if (this._details) {
+            register(this._details);
+        } else {
+            this.once('ready', () => {
+                if (!this._details) throw new Error('Details db was not initialised on ready');
+                register(this._details);
+            });
+        }
     }
 
     private static convertReadRequestToDatabaseQuery(request: ReadEventMessage) {

--- a/src/database/EventDatabaseInterface.ts
+++ b/src/database/EventDatabaseInterface.ts
@@ -223,6 +223,12 @@ export class EventDatabase extends GenericMongoDatabase<ReadEventMessage, Create
             query.author = request.userID;
         }
 
+        if (request.stateIn) {
+            query.state = {
+                $in: request.stateIn,
+            };
+        }
+
         return query;
     }
 

--- a/tests/db/event/create.test.ts
+++ b/tests/db/event/create.test.ts
@@ -70,7 +70,19 @@ describe('create messages of states', () => {
             .toHaveProperty('venues', ['a', 'b']);
         expect(query[0])
             .toHaveProperty('attendance', 1245);
-        expect(haveNoAdditionalKeys(query[0], ['id', 'name', 'state', 'ents', 'end', 'start', 'venues', 'attendance', 'author']));
+        // TODO: migrate to value from uemscommlib
+        expect(haveNoAdditionalKeys(query[0], [
+            'id',
+            'name',
+            'state',
+            'ents',
+            'end',
+            'start',
+            'venues',
+            'attendance',
+            'author',
+            'reserved',
+        ]));
     });
 
     it('should not add additional properties on create objects', async () => {
@@ -112,6 +124,18 @@ describe('create messages of states', () => {
             .toHaveProperty('venues', ['a', 'b']);
         expect(query[0])
             .toHaveProperty('attendance', 1245);
-        expect(haveNoAdditionalKeys(query[0], ['id', 'name', 'state', 'ents', 'end', 'start', 'venues', 'attendance', 'author']));
+        // TODO: migrate to value from uemscommlib
+        expect(haveNoAdditionalKeys(query[0], [
+            'id',
+            'name',
+            'state',
+            'ents',
+            'end',
+            'start',
+            'venues',
+            'attendance',
+            'author',
+            'reserved',
+        ]));
     });
 });


### PR DESCRIPTION
Across all elements this includes:

## [events](https://github.com/ents-crew/uems-event-micro-dionysus)
* Adds support for searching by state set
  * This now allows you to specify an array of states and return events which contain at least one of those states. This is used to back the ops planning workflow to retrieve all events based on their states
* Adding event reservation support
  * This allows events to be submitted but not reserve the space. This is not rolled out fully into the system yet and needs some integration into the frontend and when the admin interface gets built there will be a default option. This will allow it to either act like the old system (anyone can book overlapping events) or like the new system (a booking request reserved the space)
* Integrates an entire new AMQPlib based logging system
  * This is presently integrated with greylog locally but could be linked into any system - there is no official solution here. 
* Adding request ID to logging
  * This allows correlational tracking through all services

## [frontend](https://github.com/ents-crew/uems-frontend-themis)
* Adds ops planning workflow
  * This will list all records that are in the review states or do not have the space reserved. 
* Adds new calendar to the frontend
  * This new calendar models the google calendar layout including record stacking and seems to work pretty well. This will allow you to get a better overview. This needs some additional tweaks to integrate more fully
* Makes frontend more modular for events and venues
  * This allows displaying an already loaded element, not pulling it again from the API. This needs to be rolled out further to other view pages but is working well
* Adds venue chips to the frontend
  * Name describes them, a better way to view the venues on the event view pages and more
* Removes user linking from comments
  * User pages are not important and have been removed from the plans from the time being
* Remedies tab pane sizing on frontend
  * They now fill the page

## [gateway](https://github.com/ents-crew/uems-gateway)
* Adding configuration to gateway
  * Configuration is backed by mongodb in a new collection.
* Adding review states with associated routes
  * Review states are added into the configuration in the database and there is a general config object through which these values will be pulled. It only has get paths right now, these will be extended further when the admin interface is built
* Adding basic request caching to speed up loading
  * This is not an ideal solution but caching will be a bigger job so needs to be moved over to a new feature branch

## [hub](https://github.com/ents-crew/uems-hub)
* Added requestID to all internal messages
  * Request logging is working well!